### PR TITLE
fixed persistence issue using JPA AttributeConverter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-		<quarkus.platform.version>2.4.1.Final</quarkus.platform.version>
+		<quarkus.platform.version>2.5.1.Final</quarkus.platform.version>
 		<surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
 	</properties>
 	<dependencyManagement>
@@ -50,11 +50,6 @@
 		<dependency>
 			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-arc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.quarkiverse.hibernatetypes</groupId>
-			<artifactId>quarkus-hibernate-types</artifactId>
-			<version>0.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.quarkus</groupId>

--- a/src/main/java/io/quarkus/mcve/entity/Example.java
+++ b/src/main/java/io/quarkus/mcve/entity/Example.java
@@ -1,26 +1,19 @@
 package io.quarkus.mcve.entity;
 
-import java.util.Map;
+import io.quarkus.mcve.jpa.MapJsonConverter;
 
-import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-
-import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
-
-import io.quarkiverse.hibernate.types.json.JsonBinaryType;
-import io.quarkiverse.hibernate.types.json.JsonTypes;
+import java.util.Map;
 
 @Entity
-@TypeDef(name = JsonTypes.JSON_BIN, typeClass = JsonBinaryType.class)
 public class Example {
 
     @Id
     private int id;
 
-    @Type(type = JsonTypes.JSON_BIN)
-    @Column(columnDefinition = JsonTypes.JSON_BIN)
+    @Convert(converter = MapJsonConverter.class)
     private Map<String, Object> content;
 
     public int getId() {

--- a/src/main/java/io/quarkus/mcve/jpa/MapJsonConverter.java
+++ b/src/main/java/io/quarkus/mcve/jpa/MapJsonConverter.java
@@ -1,0 +1,31 @@
+package io.quarkus.mcve.jpa;
+
+import io.vertx.core.json.JsonObject;
+import javax.persistence.AttributeConverter;
+import java.util.Map;
+
+/**
+ * In Hibernate Reactive, AttributeConverter is pointed as the preferable solution
+ *  to handle custom db serialization.
+ * -> Source: http://hibernate.org/reactive/documentation/1.0/reference/html_single/#_custom_types
+ *
+ * This issue from Quarkus repository pointed me to this direction:
+ *   -> https://github.com/hibernate/hibernate-reactive/issues/279
+ *
+ * Jackson already handle OK the serialization from attribute which is a Map,
+ * and the Postgres Reactive Driver already know how to pass JsonObject to the
+ * jsonb and json column types, so the solution is very simple and does not
+ * require another dependencies
+ */
+public class MapJsonConverter implements AttributeConverter<Map, JsonObject> {
+
+    @Override
+    public JsonObject convertToDatabaseColumn(Map map) {
+        return new JsonObject(map);
+    }
+
+    @Override
+    public Map convertToEntityAttribute(JsonObject jsonObject) {
+        return jsonObject.getMap();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,5 @@ quarkus.datasource.username=mcve
 quarkus.datasource.password=mcve
 quarkus.datasource.reactive.url=postgresql://localhost:5435/mcve
 quarkus.hibernate-orm.log.sql=true
+
+quarkus.http.host=0.0.0.0


### PR DESCRIPTION
In Hibernate Reactive, AttributeConverter is pointed as the preferable solution
to handle custom db serialization.
-> Source: http://hibernate.org/reactive/documentation/1.0/reference/html_single/#_custom_types

This issue from Quarkus repository pointed me to this direction:
  -> https://github.com/hibernate/hibernate-reactive/issues/279

Jackson already handle OK the serialization from attribute which is a Map, 
and the Postgres Reactive Driver already know how to pass JsonObject to the
`jsonb` and `json` column types, so the solution is very simple and does not
require another dependencies.